### PR TITLE
Only consider phpcs missing if it's not installed by composer

### DIFF
--- a/tests/tools/test_phpcs.py
+++ b/tests/tools/test_phpcs.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from unittest import skipIf
 from nose.tools import eq_
 
-phpcs_missing = not(composer_exists('phpcs') or in_path('phpcs'))
+phpcs_missing = not(composer_exists('phpcs'))
 
 
 class Testphpcs(TestCase):


### PR DESCRIPTION
Trying to fix the build error when building the docker container https://quay.io/repository/freshbooks/lint-review/build/3145d2a7-682d-4b53-8e94-f88e47280fbe

phpcs is in the path but not in `vendor/bin/phpcs`